### PR TITLE
Cruise: Change model input file and update broken link 

### DIFF
--- a/cruise/airsea_data.ipynb
+++ b/cruise/airsea_data.ipynb
@@ -39,7 +39,7 @@
     "rain = 0.0 # mm/hour\n",
     "mastHeight = 8.0\n",
     "cloudCover = 7.0 # oktas\n",
-    "QswIdeal = 970.0 # https://clearskycalculator.com/pyranometer.htm"
+    "QswIdeal = 970.0 # Model Estimated Shortwave from https://clearskycalculator.com/ "
    ]
   },
   {
@@ -93,7 +93,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "roms",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -107,10 +107,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
-  },
-  "orig_nbformat": 4
+   "version": "3.11.5"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/cruise/extract_salt_temp_roms_from_metno_thredds.ipynb
+++ b/cruise/extract_salt_temp_roms_from_metno_thredds.ipynb
@@ -113,12 +113,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = 'https://thredds.met.no/thredds/dodsC/fjordos/operational_archive_daily_agg'\n",
+    "date = \"20230928\"  # date is needed for correct file name\n",
+    "filename = f\"https://thredds.met.no/thredds/dodsC/fjordos/operational_archive/complete_archive/ocean_his.nc_{date}00\"\n",
+    "\n",
     "nc       = netCDF4.Dataset(filename)\n",
     "lat      = [59.88] \n",
     "lon      = [10.65]\n",
     "name     = ['Nesoddetangen_example']\n",
-    "dates    = [datetime.datetime(2023,9,25,12)]"
+    "times    = [datetime.datetime(2023,9,28,12)]  # Format year, month, day, hour. Date needs to be the same as  \"date\" above."
    ]
   },
   {
@@ -215,9 +217,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:.conda-nils_production-10-2022_rhel8] *",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-.conda-nils_production-10-2022_rhel8-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -229,7 +231,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/cruise/extract_salt_temp_roms_from_metno_thredds.ipynb
+++ b/cruise/extract_salt_temp_roms_from_metno_thredds.ipynb
@@ -131,7 +131,7 @@
    "outputs": [],
    "source": [
     "# Check all arrays length:\n",
-    "if not (len(lat) == len(lon) == len(name) == len(dates)):\n",
+    "if not (len(lat) == len(lon) == len(name) == len(times)):   \n",
     "    print('Error in array lengths')\n",
     "    raise()"
    ]
@@ -197,7 +197,7 @@
     "# Loop over all stations:\n",
     "for i in range(len(name)):\n",
     "    x, y = roms_latlon2xy(nc, lat[i], lon[i]) # find x and y indexes\n",
-    "    t    = np.where(netCDF4.num2date(nc.variables['ocean_time'][:], nc.variables['ocean_time'].units) == dates[i])[0][0] # find time index\n",
+    "    t    = np.where(netCDF4.num2date(nc.variables['ocean_time'][:], nc.variables['ocean_time'].units) == times[i])[0][0] # find time index\n",
     "    mask = nc.variables['mask_rho'][:]\n",
     "    if mask[y,x] == 0:\n",
     "        print('Position is on land, will find nearest wet gridpoint')\n",


### PR DESCRIPTION
I've made two updates

1. The input file in "Extract salt and temp from ROMS file on MET Norway thredds" was an aggregate file that didn't go long enough back in time to cover the dates for the cruise. I've updated the input file so that files are read from [the complete archive](https://thredds.met.no/thredds/catalog/fjordos/operational_archive/complete_archive/catalog.html) is used instead. 
2. Updated the broken link to the clear sky calculator for ideal shortwave calculation in airsea_data.ipynb